### PR TITLE
OpenSSL 3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## 1.2.0.pre.3 - 05/05/2023
+  * Update mechanism for verifying RSA public keys to work on OpenSSL 3
+  * Ensure state persists between initial call and on callback
+
 ## 1.1.0 - 06/13/2022
   * Add "prompt" parameter to be persisted on request, allowing for silent authentication (among other things)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## 1.2.0.pre.3 - 05/05/2023
+## 1.2.0 - 05/05/2023
   * Update mechanism for verifying RSA public keys to work on OpenSSL 3
   * Ensure state persists between initial call and on callback
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-doximity-oauth2 (1.2.0.pre.3)
+    omniauth-doximity-oauth2 (1.2.0)
       activesupport
       faraday
       jwt

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-doximity-oauth2 (1.1.0)
+    omniauth-doximity-oauth2 (1.2.0.pre.3)
       activesupport
       faraday
       jwt

--- a/lib/omniauth-doximity-oauth2/crypto.rb
+++ b/lib/omniauth-doximity-oauth2/crypto.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module OmniAuth
+  module DoximityOauth2
+    # Static crypto methods
+    class Crypto
+      class << self
+        def create_rsa_key(n, e)
+          data_sequence = OpenSSL::ASN1::Sequence([
+                                                    OpenSSL::ASN1::Integer(base64_to_long(n)),
+                                                    OpenSSL::ASN1::Integer(base64_to_long(e))
+                                                  ])
+          asn1 = OpenSSL::ASN1::Sequence(data_sequence)
+          OpenSSL::PKey::RSA.new(asn1.to_der)
+        end
+
+        private
+
+        def base64_to_long(data)
+          decoded_with_padding = Base64.urlsafe_decode64(data) + Base64.decode64("==")
+          decoded_with_padding.to_s.unpack("C*").map do |byte|
+            byte_to_hex(byte)
+          end.join.to_i(16)
+        end
+
+        def byte_to_hex(int)
+          int < 16 ? "0#{int.to_s(16)}" : int.to_s(16)
+        end
+      end
+    end
+  end
+end

--- a/lib/omniauth-doximity-oauth2/errors.rb
+++ b/lib/omniauth-doximity-oauth2/errors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Omniauth
+module OmniAuth
   module DoximityOauth2
     # Error for failed request to get public keys, for JWK verification
     class JWKSRequestError < StandardError

--- a/lib/omniauth-doximity-oauth2/version.rb
+++ b/lib/omniauth-doximity-oauth2/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module DoximityOauth2
-    VERSION = "1.2.0.pre.3"
+    VERSION = "1.2.0"
   end
 end

--- a/lib/omniauth-doximity-oauth2/version.rb
+++ b/lib/omniauth-doximity-oauth2/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Omniauth
+module OmniAuth
   module DoximityOauth2
-    VERSION = "1.1.0"
+    VERSION = "1.2.0.pre.3"
   end
 end

--- a/omniauth-doximity-oauth2.gemspec
+++ b/omniauth-doximity-oauth2.gemspec
@@ -5,7 +5,7 @@ require File.expand_path('lib/omniauth-doximity-oauth2/version', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name          = "omniauth-doximity-oauth2"
-  spec.version       = Omniauth::DoximityOauth2::VERSION
+  spec.version       = OmniAuth::DoximityOauth2::VERSION
   spec.authors       = ["William Harvey"]
   spec.email         = ["wharvey@doximity.com"]
   spec.description   = 'OmniAuth strategy for Doximity, supporting OIDC, and using PKCE'


### PR DESCRIPTION
Overview
--------

In OpenSSL 3, `set_key` is not functional. This is an alternative way of creating an RSA key instance that works in OpenSSL 3. On Ubuntu 22 servers, this is a mandatory upgrade.

This also adds a small improvement to ensure state is persisted between authorization and the callback

Testing Instructions
---------------

On a server running with Open SSL 3.x, test a Doximity login
