### PR TITLE
Replace mofo_backend with core_identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Back-end team
-* @doximity/mofo_backend
+* @doximity/core_identity
 
 # Infra Automation
 /.circleci @doximity/infra_automation_reviewers


### PR DESCRIPTION
Story link: [CSIDENTITY-1042](https://doximity.atlassian.net/browse/CSIDENTITY-1042)

Overview
--------

Retiring the "mofo_backend" group.

QA Instructions
---------------

no-qa


[CSIDENTITY-1042]: https://doximity.atlassian.net/browse/CSIDENTITY-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ