### PR TITLE
Handle 'theme' parameter being passed to the OAuth authorization endpoint

### DIFF
--- a/lib/omniauth/strategies/doximity_oauth2.rb
+++ b/lib/omniauth/strategies/doximity_oauth2.rb
@@ -20,7 +20,7 @@ module OmniAuth
 
       option :pkce, true
 
-      option :authorize_options, %i[scope prompt]
+      option :authorize_options, %i[scope prompt theme]
 
       option :client_options, {
         site: "https://auth.doximity.com",


### PR DESCRIPTION
Overview
--------

We need a `theme` parameter to be passed along to the OAuth authorization endpoint, useful for some applications.

We are using the `authorize_options` class method ([see source from omniauth-oauth2](https://github.com/omniauth/omniauth-oauth2/blob/3e7ee11c84153e6f0c19d38a5e63cda550f6925c/lib/omniauth/strategies/oauth2.rb#L27)).

