### PR TITLE
Allow sending query params to the callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## 1.4.0 - 10/24/2023
+  * Support sending "callback_query_params" through the request phase, which will be treated as additional state params.
+
 ## 1.3.0 - 08/09/2023
   * Handle 'theme' parameter to be passed along to the OAuth authorization
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-doximity-oauth2 (1.3.0)
+    omniauth-doximity-oauth2 (1.4.0)
       activesupport
       faraday
       jwt

--- a/lib/omniauth-doximity-oauth2/version.rb
+++ b/lib/omniauth-doximity-oauth2/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module DoximityOauth2
-    VERSION = "1.3.0"
+    VERSION = "1.4.0"
   end
 end

--- a/lib/omniauth/strategies/doximity_oauth2.rb
+++ b/lib/omniauth/strategies/doximity_oauth2.rb
@@ -111,6 +111,7 @@ module OmniAuth
       end
 
       def callback_url
+        puts "TEST options[:callback_url] #{options[:callback_url]} - nil? #{options[:callback_url].nil?}"
         options[:callback_url] || full_host + script_name + callback_path + callback_query_params
       end
 

--- a/lib/omniauth/strategies/doximity_oauth2.rb
+++ b/lib/omniauth/strategies/doximity_oauth2.rb
@@ -111,7 +111,11 @@ module OmniAuth
       end
 
       def callback_url
-        options[:callback_url] || full_host + script_name + callback_path
+        options[:callback_url] || full_host + script_name + callback_path + callback_query_params
+      end
+
+      def callback_query_params
+        request.params[:callback_query_params] || ""
       end
 
       def prune(hash)

--- a/lib/omniauth/strategies/doximity_oauth2.rb
+++ b/lib/omniauth/strategies/doximity_oauth2.rb
@@ -111,14 +111,11 @@ module OmniAuth
       end
 
       def callback_url
-        puts "TEST options[:callback_url] #{options[:callback_url]} - nil? #{options[:callback_url].nil?}"
         options[:callback_url] || full_host + script_name + callback_path + callback_query_params
       end
 
       def callback_query_params
-        puts "TEST request.params[:callback_query_params] #{request.params[:callback_query_params]}"
-        puts "TEST request.params[\"callback_query_params\"] #{request.params["callback_query_params"]}"
-        request.params[:callback_query_params] || ""
+        request.params["callback_query_params"] || ""
       end
 
       def prune(hash)

--- a/lib/omniauth/strategies/doximity_oauth2.rb
+++ b/lib/omniauth/strategies/doximity_oauth2.rb
@@ -115,6 +115,8 @@ module OmniAuth
       end
 
       def callback_query_params
+        puts "TEST request.params[:callback_query_params] #{request.params[:callback_query_params]}"
+        puts "TEST request.params[\"callback_query_params\"] #{request.params["callback_query_params"]}"
         request.params[:callback_query_params] || ""
       end
 


### PR DESCRIPTION
Overview
--------

Allows forwarding a query string to the callback by setting `:callback_query_params` on the request params

Testing Instructions
---------------

To be tested internally