### PR TITLE
Add login hint to auth options

### DIFF
--- a/lib/omniauth/strategies/doximity_oauth2.rb
+++ b/lib/omniauth/strategies/doximity_oauth2.rb
@@ -20,7 +20,7 @@ module OmniAuth
 
       option :pkce, true
 
-      option :authorize_options, %i[scope prompt theme]
+      option :authorize_options, %i[scope prompt theme login_hint]
 
       option :client_options, {
         site: "https://auth.doximity.com",


### PR DESCRIPTION
Overview
--------

Adds `login_hint` to authorization options, so it can be passed through oauth requests

Testing Instructions
---------------

Tested internally on oauth testing app
